### PR TITLE
SPF URL Params

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -10,7 +10,9 @@ $app->get('/', function (Request $request, Response $response) {
 });
 
 $app->get('/spf', function (Request $request, Response $response) {
-    return $this->view->render($response, 'spf.twig');
+    $params = $request->getQueryParams();
+
+    return $this->view->render($response, 'spf.twig', compact('params'));
 });
 
 $app->post('/spf', function (Request $request, Response $response) {

--- a/views/spf.twig
+++ b/views/spf.twig
@@ -4,7 +4,7 @@
 
 {% block content %}
 
-    {% if params %}
+    {% if status %}
 
         <p>SPF Validation Results:</p>
 


### PR DESCRIPTION
Allows IP and Email fields to be pre-filled through GET Parameters.

- [x] Check SPF Debugged works normally
- [x] Check SPF Debugger works with the "ip" and "email" GET Parameters